### PR TITLE
Add camera reset and autoloot options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 sekiro-set-fps
 sekiro-set-resolution
+.cache

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Download the latest release, or build it yourself.
 ```sh
 ./sekirofpsunlock 30 set-resolution 2560 2560 1080 set-fps 144
 ```
+#### Set all options in a single command
+```sh
+./sekirofpsunlock 30 set-resolution 2560 2560 1080 set-fps 144 disable-camera-reset autoloot
+```
 #### Starting from Steam
 Note: before running the patcher from Steam, you should run it from the terminal once to make sure that the patcher works without any errors.
 
@@ -103,6 +107,16 @@ will fail. As things are currently, you'd need to restart the game to try a
 different resolution. It's possible to have it working, but I don't see why
 anyone would want to set the resolution more than once per play session, so
 I didn't bother implementing it.
+#### Disable Camera Reset
+```sh
+./sekirofpsunlock 30 disable-camera-reset
+```
+Normally, if you press the target lock-on key and no target is in sight the game will reset and center the camera position on your character's facing direction. Including this option disabled that behavior.
+#### Autoloot
+```sh
+./sekirofpsunlock 30 autoloot
+```
+Including this option will pick up all loot an enemy drops automatically as long as you are in pick-up range (untested).
 ##### UI issues
 ###### 21:9
 ![UI elements not matching the resolution](https://staticdelivery.nexusmods.com/mods/2763/images/240/240-1606870250-478083709.png)
@@ -146,11 +160,11 @@ The last step is actually activating the mod loader. It is loaded through `dinpu
 
 ![DLL override example](override.png)
 
-For the steam launcher the settings would be 
+For the steam launcher the settings would be
 
 ```
 /home/user/sekirofpsunlock 30 set-resolution 2560 2560 1080 set-fps 144 & WINEDLLOVERRIDES=dinput8=n,b %command%
-``` 
+```
 ###### 16:10
 Unfortunately, there is no mod that fixes the UI for 16:10, so Steam Deck users are out of luck. The game is still perfectly playable with patched resolution, of course, but the UI will be a little bit off.
 #### Combined

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('sekirofpsunlock', 'c', default_options : ['c_std=c17'], version : '0.2.3')
+project('sekirofpsunlock', 'c', default_options : ['c_std=c17'], version : '0.3.0')
 
 c_args = ['-Wall', '-Wextra', '-Wpedantic']
 
@@ -9,4 +9,5 @@ executable('sekirofpsunlock',
            'src/sekiro.c',
            'src/fps.c',
            'src/resolution.c',
+           'src/extras.c',
            c_args : c_args)

--- a/src/extras.c
+++ b/src/extras.c
@@ -1,0 +1,197 @@
+#include "fps.h"
+
+#include "signals.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <math.h>
+#include <stdlib.h>
+#include <sys/ptrace.h>
+#include <time.h>
+
+static struct ignorable_byte camera_reset[] = {
+    // C6 86 ?? ?? 00 00 ?? F3 0F 10 8E ?? ?? 00 00
+    { .is_ignored = false, .value = 0xc6 },
+    { .is_ignored = false, .value = 0x86 },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = false, .value = 0x00 },
+    { .is_ignored = false, .value = 0x00 },
+    { .is_ignored = true },
+    { .is_ignored = false, .value = 0xf3 },
+    { .is_ignored = false, .value = 0x0f },
+    { .is_ignored = false, .value = 0x10 },
+    { .is_ignored = false, .value = 0x8e },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = false, .value = 0x00 },
+    { .is_ignored = false, .value = 0x00 },
+};
+
+static struct ignorable_byte autoloot[] = {
+    // C6 85 ?? ?? ?? ?? ?? B0 01 EB ?? C6 85 ?? ?? ?? ?? ?? 32 C0
+    { .is_ignored = false, .value = 0xc6 },
+    { .is_ignored = false, .value = 0x85 },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = false, .value = 0xb0 },
+    { .is_ignored = false, .value = 0x01 },
+    { .is_ignored = false, .value = 0xeb },
+    { .is_ignored = true },
+    { .is_ignored = false, .value = 0xc6 },
+    { .is_ignored = false, .value = 0x85 },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = true },
+    { .is_ignored = false, .value = 0x32 },
+    { .is_ignored = false, .value = 0xc0 },
+};
+
+static bool patch_camera_reset_with_section(struct context *context, uint8_t *section_bytes, size_t section_bytes_size, size_t section_position)
+{
+	time_t start_time = time(NULL);
+	if ((time_t)-1 == start_time) {
+		perror("time() failed");
+		return false;
+	}
+
+	size_t pattern_camera_reset_index = 0;
+	time_t current_time = start_time;
+	while (true) {
+		if (got_sigterm) {
+			fprintf(stderr, "got SIGTERM, exiting\n");
+			return false;
+		}
+
+		if (got_sigchld) {
+			if (ptrace(PTRACE_CONT, context->pid, NULL, NULL) == -1) {
+				perror("ptrace(PTRACE_CONT) failed");
+				return false;
+			}
+			got_sigchld = 0;
+		}
+
+		if (find_pattern(camera_reset, sizeof(camera_reset) / sizeof(struct ignorable_byte), context->f, section_bytes, section_bytes_size, section_position, &pattern_camera_reset_index)) {
+			stop_and_wait(context);
+			break;
+		}
+
+		current_time = time(NULL);
+		if ((time_t)-1 == current_time) {
+			perror("time() failed");
+			return false;
+		}
+		if ((current_time - start_time) > context->timeout) {
+			fprintf(stderr, "timeout reached while looking for camera reset pattern\n");
+			return false;
+		}
+	}
+
+	size_t camera_reset_value_index = pattern_camera_reset_index + 6;
+    uint8_t camera_reset_enabled = 0x00; // 0x00 = disabled, 0x01 = enabled
+	if (!seek_and_write_bytes(&camera_reset_enabled, sizeof(camera_reset_enabled), section_position + camera_reset_value_index, context->f)) {
+		fprintf(stderr, "seek_and_write_bytes() failed\n");
+		return false;
+	}
+
+	return true;
+}
+
+bool patch_camera_reset(struct context *context)
+{
+	size_t section_position;
+	size_t section_size = 0;
+	if (!find_section_info(".text", context->f, &section_position, &section_size)) {
+		fprintf(stderr, "find_section_info(\".text\", ...) failed\n");
+		return false;
+	}
+
+	uint8_t *section_buffer = calloc(section_size, sizeof(uint8_t));
+	if (!section_buffer) {
+		fprintf(stderr, "calloc() failed\n");
+		return false;
+	}
+
+	bool success = patch_camera_reset_with_section(context, section_buffer, section_size, section_position);
+
+	free(section_buffer);
+
+	return success;
+}
+
+static bool patch_autoloot_with_section(struct context *context, uint8_t *section_bytes, size_t section_bytes_size, size_t section_position)
+{
+	time_t start_time = time(NULL);
+	if ((time_t)-1 == start_time) {
+		perror("time() failed");
+		return false;
+	}
+
+	size_t pattern_autoloot_index = 0;
+	time_t current_time = start_time;
+	while (true) {
+		if (got_sigterm) {
+			fprintf(stderr, "got SIGTERM, exiting\n");
+			return false;
+		}
+
+		if (got_sigchld) {
+			if (ptrace(PTRACE_CONT, context->pid, NULL, NULL) == -1) {
+				perror("ptrace(PTRACE_CONT) failed");
+				return false;
+			}
+			got_sigchld = 0;
+		}
+
+		if (find_pattern(autoloot, sizeof(autoloot) / sizeof(struct ignorable_byte), context->f, section_bytes, section_bytes_size, section_position, &pattern_autoloot_index)) {
+			stop_and_wait(context);
+			break;
+		}
+
+		current_time = time(NULL);
+		if ((time_t)-1 == current_time) {
+			perror("time() failed");
+			return false;
+		}
+		if ((current_time - start_time) > context->timeout) {
+			fprintf(stderr, "timeout reached while looking for autoloot pattern\n");
+			return false;
+		}
+	}
+
+	size_t autoloot_value_index = pattern_autoloot_index + 18;
+    uint8_t autoloot_enabled[2] = { 0xb0, 0x01 }; // b0 01 = enabled, 32 c0 = disabled
+	if (!seek_and_write_bytes((uint8_t *)&autoloot_enabled, sizeof(autoloot_enabled), section_position + autoloot_value_index, context->f)) {
+		fprintf(stderr, "seek_and_write_bytes() failed\n");
+		return false;
+	}
+
+	return true;
+}
+
+bool patch_autoloot(struct context *context)
+{
+	size_t section_position;
+	size_t section_size = 0;
+	if (!find_section_info(".text", context->f, &section_position, &section_size)) {
+		fprintf(stderr, "find_section_info(\".text\", ...) failed\n");
+		return false;
+	}
+
+	uint8_t *section_buffer = calloc(section_size, sizeof(uint8_t));
+	if (!section_buffer) {
+		fprintf(stderr, "calloc() failed\n");
+		return false;
+	}
+
+	bool success = patch_autoloot_with_section(context, section_buffer, section_size, section_position);
+
+	free(section_buffer);
+
+	return success;
+}

--- a/src/extras.c
+++ b/src/extras.c
@@ -1,4 +1,4 @@
-#include "fps.h"
+#include "extras.h"
 
 #include "signals.h"
 

--- a/src/extras.h
+++ b/src/extras.h
@@ -1,0 +1,7 @@
+#include "common.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+
+bool patch_camera_reset(struct context *context);
+bool patch_autoloot(struct context *context);

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include "sekiro.h"
 #include "fps.h"
 #include "resolution.h"
+#include "extras.h"
 
 #include <assert.h>
 #include <dirent.h>
@@ -22,6 +23,8 @@
 
 #define COMMAND_FPS "set-fps"
 #define COMMAND_RESOLUTION "set-resolution"
+#define COMMAND_CAMERA_RESET "disable-camera-reset"
+#define COMMAND_AUTOLOOT "autoloot"
 
 static time_t uint32_to_time(uint32_t value)
 {
@@ -64,6 +67,22 @@ static bool handle_arguments(struct context *context, char **arguments, int argu
 
 			arguments += 4;
 			arguments_size -= 4;
+		} else if (!strncmp(*arguments, COMMAND_CAMERA_RESET, strlen(COMMAND_CAMERA_RESET))) {
+			if (!patch_camera_reset(context)) {
+				fprintf(stderr, "patch_camera_reset() failed\n");
+				return false;
+			}
+
+			arguments += 1;
+			arguments_size -= 1;
+		} else if (!strncmp(*arguments, COMMAND_AUTOLOOT, strlen(COMMAND_AUTOLOOT))) {
+			if (!patch_autoloot(context)) {
+				fprintf(stderr, "patch_autoloot() failed\n");
+				return false;
+			}
+
+			arguments += 1;
+			arguments_size -= 1;
 		} else {
 			fprintf(stderr, "unknown command: %s\n", *arguments);
 


### PR DESCRIPTION
Adds a couple of options I personally wanted from the Windows FPS unlocker. It works for me, but not extensively tested. Follows the base repository style except that I put both options in one file.

See https://github.com/uberhalit/SekiroFpsUnlockAndMore/blob/master/SekiroFpsUnlockAndMore/GameData.cs#L278 lines 278 to 295.

Use as is or modify or close if you want; I'm using this myself and don't plan on maintaining it.